### PR TITLE
Feature/localho st

### DIFF
--- a/sample-network/README.md
+++ b/sample-network/README.md
@@ -130,7 +130,7 @@ Or set the `peer` CLI context to org1 peer1:
 ```shell
 export FABRIC_CFG_PATH=${PWD}/temp/config
 export CORE_PEER_LOCALMSPID=Org1MSP
-export CORE_PEER_ADDRESS=test-network-org1-peer1-peer.${TEST_NETWORK_DOMAIN}:443
+export CORE_PEER_ADDRESS=test-network-org1-peer1-peer.localho.st:443
 export CORE_PEER_TLS_ENABLED=true
 export CORE_PEER_MSPCONFIGPATH=${PWD}/temp/enrollments/org1/users/org1admin/msp
 export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/temp/channel-msp/peerOrganizations/org1/msp/tlscacerts/tlsca-signcert.pem
@@ -175,7 +175,7 @@ peer lifecycle \
   --version       1 \
   --package-id    ${PACKAGE_ID} \
   --sequence      1 \
-  --orderer       test-network-org0-orderersnode1-orderer.${TEST_NETWORK_DOMAIN}:443 \
+  --orderer       test-network-org0-orderersnode1-orderer.localho.st:443 \
   --tls --cafile  $PWD/temp/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem  
   
 peer lifecycle \
@@ -184,7 +184,7 @@ peer lifecycle \
   --name          conga-nft-contract \
   --version       1 \
   --sequence      1 \
-  --orderer       test-network-org0-orderersnode1-orderer.${TEST_NETWORK_DOMAIN}:443 \
+  --orderer       test-network-org0-orderersnode1-orderer.localho.st:443 \
   --tls --cafile  $PWD/temp/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem  
 
 ```
@@ -221,7 +221,7 @@ Launch the [Fabric Operations Console](https://github.com/hyperledger-labs/fabri
 network console
 ```
 
-- open `https://test-network-hlf-console-console.${TEST_NETWORK_DOMAIN}`
+- open `https://test-network-hlf-console-console.localho.st`
 - Accept the self-signed TLS certificate
 - Log in as `admin:password`
 - [Build a network](https://cloud.ibm.com/docs/blockchain?topic=blockchain-ibp-console-build-network)

--- a/sample-network/README.md
+++ b/sample-network/README.md
@@ -49,26 +49,27 @@ While this IP address varies from system to system, here are some common guideli
 
 - For KIND on OSX, find the host IP address by resolving `host.docker.internal` in a docker container.  E.g.: 
 ```shell
-$ docker run -it --rm alpine nslookup host.docker.internal
-
+docker run -it --rm alpine nslookup host.docker.internal
+```
+```shell
+Non-authoritative answer:
 Name:	host.docker.internal
 Address: 192.168.65.2
 ```
-- On machines running an embedded virtual machine (WSL, Virtualbox, VMWare, etc.), use the IP address of the
+- On systems with an embedded virtual machine (WSL, Virtualbox, VMWare, etc.), use the IP address of the
   bridge interface for the guest VM.
 - On machines running Rancher / k3s, use the host IP address assigned by DHCP (e.g. 192.168.0.4)
-- On environments with access to public DNS (e.g. IBM cloud, Fyre, EKS, etc.), use DNS: 
-```shell
-export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE=false
-export TEST_NETWORK_INGRESS_DOMAIN=my-blockchain.example.com
-```
-
 
 After finding a suitable IP address, set the cluster ingress for the network.  E.g.: 
 ```shell
 export TEST_NETWORK_INGRESS_IPADDR=192.168.65.2
 ```
 
+Or for environments with access to a public DNS wildcard record, bypass the IP override and directly set the cluster domain: 
+```shell
+export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE=false
+export TEST_NETWORK_INGRESS_DOMAIN=my-blockchain.example.com
+```
 
 
 ### Fabric Binaries 

--- a/sample-network/config/cas/org0-ca.yaml
+++ b/sample-network/config/cas/org0-ca.yaml
@@ -99,7 +99,7 @@ spec:
           expiry: 87600h0m0s
   customNames:
     pvc: {}
-  domain: "${DOMAIN}"
+  domain: "${INGRESS_DOMAIN}"
   images:
     caImage: ${CA_IMAGE}
     caTag: ${CA_IMAGE_LABEL}

--- a/sample-network/config/cas/org1-ca.yaml
+++ b/sample-network/config/cas/org1-ca.yaml
@@ -92,7 +92,7 @@ spec:
           expiry: 87600h0m0s
   customNames:
     pvc: {}
-  domain: "${DOMAIN}"
+  domain: "${INGRESS_DOMAIN}"
   images:
     caImage: ${CA_IMAGE}
     caTag: ${CA_IMAGE_LABEL}

--- a/sample-network/config/cas/org2-ca.yaml
+++ b/sample-network/config/cas/org2-ca.yaml
@@ -92,7 +92,7 @@ spec:
           expiry: 87600h0m0s
   customNames:
     pvc: {}
-  domain: "${DOMAIN}"
+  domain: "${INGRESS_DOMAIN}"
   # imagePullSecrets:
   # - regcred
   images:

--- a/sample-network/config/core.yaml
+++ b/sample-network/config/core.yaml
@@ -366,7 +366,7 @@ peer:
         reconnectTotalTimeThreshold: 3600s
 
         # It sets the delivery service <-> ordering service node connection timeout
-        connTimeout: 3s
+        connTimeout: 10s
 
         # It sets the delivery service maximal delay between consecutive retries
         reConnectBackoffThreshold: 3600s

--- a/sample-network/config/orderers/org0-orderers.yaml
+++ b/sample-network/config/orderers/org0-orderers.yaml
@@ -22,7 +22,7 @@ metadata:
   name: org0-orderers
 spec:
   version: "${FABRIC_VERSION}"
-  domain: "${DOMAIN}"
+  domain: "${INGRESS_DOMAIN}"
   license:
     accept: true
   action:
@@ -43,7 +43,7 @@ spec:
     - enrollment:
         component:
           caname: ca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"
@@ -51,7 +51,7 @@ spec:
           enrollsecret: "orderer1pw"
         tls:
           caname: tlsca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"
@@ -64,7 +64,7 @@ spec:
     - enrollment:
         component:
           caname: ca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"
@@ -72,7 +72,7 @@ spec:
           enrollsecret: "orderer2pw"
         tls:
           caname: tlsca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"
@@ -85,7 +85,7 @@ spec:
     - enrollment:
         component:
           caname: ca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"
@@ -93,7 +93,7 @@ spec:
           enrollsecret: "orderer3pw"
         tls:
           caname: tlsca
-          cahost: test-network-org0-ca-ca.${DOMAIN}
+          cahost: test-network-org0-ca-ca.${INGRESS_DOMAIN}
           caport: "443"
           catls:
             cacert: "${ORG0_CA_CERT}"

--- a/sample-network/config/peers/org1-peer1.yaml
+++ b/sample-network/config/peers/org1-peer1.yaml
@@ -22,8 +22,8 @@ metadata:
   name: org1-peer1
 spec:
   version: "${FABRIC_VERSION}"
-  domain: "${DOMAIN}"
-  peerExternalEndpoint: "test-network-org1-peer1-peer.${DOMAIN}:443"
+  domain: "${INGRESS_DOMAIN}"
+  peerExternalEndpoint: "test-network-org1-peer1-peer.${INGRESS_DOMAIN}:443"
   license:
     accept: true
   action:
@@ -48,7 +48,7 @@ spec:
     enrollment:
       component:
         caname: ca
-        cahost: "test-network-org1-ca-ca.${DOMAIN}"
+        cahost: "test-network-org1-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG1_CA_CERT}"
@@ -56,7 +56,7 @@ spec:
         enrollsecret: "peer1pw"
       tls:
         caname: tlsca
-        cahost: "test-network-org1-ca-ca.${DOMAIN}"
+        cahost: "test-network-org1-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG1_CA_CERT}"

--- a/sample-network/config/peers/org1-peer2.yaml
+++ b/sample-network/config/peers/org1-peer2.yaml
@@ -22,8 +22,8 @@ metadata:
   name: org1-peer2
 spec:
   version: "${FABRIC_VERSION}"
-  domain: "${DOMAIN}"
-  peerExternalEndpoint: "test-network-org1-peer2-peer.${DOMAIN}:443"
+  domain: "${INGRESS_DOMAIN}"
+  peerExternalEndpoint: "test-network-org1-peer2-peer.${INGRESS_DOMAIN}:443"
   license:
     accept: true
   action:
@@ -48,7 +48,7 @@ spec:
     enrollment:
       component:
         caname: ca
-        cahost: "test-network-org1-ca-ca.${DOMAIN}"
+        cahost: "test-network-org1-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG1_CA_CERT}"
@@ -56,7 +56,7 @@ spec:
         enrollsecret: "peer2pw"
       tls:
         caname: tlsca
-        cahost: "test-network-org1-ca-ca.${DOMAIN}"
+        cahost: "test-network-org1-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG1_CA_CERT}"

--- a/sample-network/config/peers/org2-peer1.yaml
+++ b/sample-network/config/peers/org2-peer1.yaml
@@ -22,8 +22,8 @@ metadata:
   name: org2-peer1
 spec:
   version: "${FABRIC_VERSION}"
-  domain: "${DOMAIN}"
-  peerExternalEndpoint: "test-network-org2-peer1-peer.${DOMAIN}:443"
+  domain: "${INGRESS_DOMAIN}"
+  peerExternalEndpoint: "test-network-org2-peer1-peer.${INGRESS_DOMAIN}:443"
   license:
     accept: true
   action:
@@ -48,7 +48,7 @@ spec:
     enrollment:
       component:
         caname: ca
-        cahost: "test-network-org2-ca-ca.${DOMAIN}"
+        cahost: "test-network-org2-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG2_CA_CERT}"
@@ -56,7 +56,7 @@ spec:
         enrollsecret: "peer1pw"
       tls:
         caname: tlsca
-        cahost: "test-network-org2-ca-ca.${DOMAIN}"
+        cahost: "test-network-org2-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG2_CA_CERT}"

--- a/sample-network/config/peers/org2-peer2.yaml
+++ b/sample-network/config/peers/org2-peer2.yaml
@@ -22,8 +22,8 @@ metadata:
   name: org2-peer2
 spec:
   version: "${FABRIC_VERSION}"
-  domain: "${DOMAIN}"
-  peerExternalEndpoint: "test-network-org2-peer2-peer.${DOMAIN}:443"
+  domain: "${INGRESS_DOMAIN}"
+  peerExternalEndpoint: "test-network-org2-peer2-peer.${INGRESS_DOMAIN}:443"
   license:
     accept: true
   action:
@@ -48,7 +48,7 @@ spec:
     enrollment:
       component:
         caname: ca
-        cahost: "test-network-org2-ca-ca.${DOMAIN}"
+        cahost: "test-network-org2-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG2_CA_CERT}"
@@ -56,7 +56,7 @@ spec:
         enrollsecret: "peer2pw"
       tls:
         caname: tlsca
-        cahost: "test-network-org2-ca-ca.${DOMAIN}"
+        cahost: "test-network-org2-ca-ca.${INGRESS_DOMAIN}"
         caport: "443"
         catls:
           cacert: "${ORG2_CA_CERT}"

--- a/sample-network/network
+++ b/sample-network/network
@@ -62,6 +62,7 @@ context CONSOLE_PASSWORD          password
 
 # TODO: use new cc logic from test-network
 context CHANNEL_NAME              mychannel
+context ORDERER_TIMEOUT           10s
 context CHAINCODE_NAME            asset-transfer-basic
 context CHAINCODE_IMAGE           ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
 context CHAINCODE_LABEL           basic_1.0

--- a/sample-network/network
+++ b/sample-network/network
@@ -45,8 +45,9 @@ context FABRIC_CONTAINER_REGISTRY hyperledger
 context NAME                      test-network
 context NS                        $NAME
 context CLUSTER_NAME              $CLUSTER_RUNTIME
-context DOMAIN                    local.fabric.network
 context KUBE_DNS_DOMAIN           ${NS}.svc.cluster.local
+context INGRESS_DOMAIN            localho.st
+context COREDNS_DOMAIN_OVERRIDE   true
 context LOG_FILE                  network.log
 context DEBUG_FILE                network-debug.log
 context LOG_ERROR_LINES           1
@@ -55,7 +56,7 @@ context LOCAL_REGISTRY_PORT       5000
 context NGINX_HTTP_PORT           80
 context NGINX_HTTPS_PORT          443
 
-context CONSOLE_DOMAIN            $DOMAIN
+context CONSOLE_DOMAIN            ${INGRESS_DOMAIN}
 context CONSOLE_USERNAME          admin
 context CONSOLE_PASSWORD          password
 

--- a/sample-network/network
+++ b/sample-network/network
@@ -73,7 +73,7 @@ context PEER_IMAGE_LABEL          ${FABRIC_VERSION}
 context ORDERER_IMAGE             ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer
 context ORDERER_IMAGE_LABEL       ${FABRIC_VERSION}
 context TOOLS_IMAGE               ${FABRIC_CONTAINER_REGISTRY}/fabric-tools
-context TOOLS_IMAGE               ${FABRIC_VERSION}
+context TOOLS_IMAGE_LABEL         ${FABRIC_VERSION}
 context OPERATOR_IMAGE            ghcr.io/ibm-blockchain/fabric-operator
 context OPERATOR_IMAGE_LABEL      latest-amd64
 context INIT_IMAGE                registry.access.redhat.com/ubi8/ubi-minimal

--- a/sample-network/scripts/chaincode.sh
+++ b/sample-network/scripts/chaincode.sh
@@ -112,7 +112,7 @@ function invoke_chaincode() {
     -n              $cc_name \
     -C              $CHANNEL_NAME \
     -c              $@ \
-    --orderer       ${NS}-org0-orderersnode1-orderer.${DOMAIN}:443 \
+    --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
 
   sleep 2
@@ -285,7 +285,7 @@ function approve_chaincode() {
     --version       1 \
     --package-id    ${cc_id} \
     --sequence      1 \
-    --orderer       ${NS}-org0-orderersnode1-orderer.${DOMAIN}:443 \
+    --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
 
   pop_fn
@@ -306,7 +306,7 @@ function commit_chaincode() {
     --name          ${cc_name} \
     --version       1 \
     --sequence      1 \
-    --orderer       ${NS}-org0-orderersnode1-orderer.${DOMAIN}:443 \
+    --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
     --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
 
   pop_fn

--- a/sample-network/scripts/channel.sh
+++ b/sample-network/scripts/channel.sh
@@ -125,7 +125,7 @@ function enroll_org_admin() {
   FABRIC_CA_CLIENT_HOME=${ORG_ADMIN_DIR} fabric-ca-client enroll --url ${CA_URL} --tls.certfiles ${CA_DIR}/tls-cert.pem
 
   # Construct an msp config.yaml
-  CA_CERT_NAME=${NS}-${CA_NAME}-ca-$(echo $DOMAIN | tr -s . -)-${CA_PORT}.pem
+  CA_CERT_NAME=${NS}-${CA_NAME}-ca-$(echo $INGRESS_DOMAIN | tr -s . -)-${CA_PORT}.pem
 
   create_msp_config_yaml ${CA_NAME} ${CA_CERT_NAME} ${ORG_ADMIN_DIR}/msp
 
@@ -215,7 +215,7 @@ function create_genesis_block() {
   cp ${PWD}/config/core.yaml ${TEMP_DIR}/config/
 
   # The channel configtx file needs to specify dynamic elements from the environment,
-  # for instance, the ${DOMAIN} for ingress controller and service endpoints.
+  # for instance, the ${INGRESS_DOMAIN} for ingress controller and service endpoints.
   cat ${PWD}/config/configtx-template.yaml | envsubst > ${TEMP_DIR}/config/configtx.yaml
 
   FABRIC_CFG_PATH=${TEMP_DIR}/config \
@@ -251,7 +251,7 @@ function join_channel_orderer() {
   # of identity than the Docker Compose network, which transmits the orderer NODE TLS key pair directly
 
   osnadmin channel join \
-    --orderer-address ${NS}-${org}-${orderer}-admin.${DOMAIN} \
+    --orderer-address ${NS}-${org}-${orderer}-admin.${INGRESS_DOMAIN} \
     --ca-file         ${TEMP_DIR}/channel-msp/ordererOrganizations/${org}/orderers/${org}-${orderer}/tls/signcerts/tls-cert.pem \
     --client-cert     ${TEMP_DIR}/enrollments/${org}/users/${org}admin/tls/signcerts/cert.pem \
     --client-key      ${TEMP_DIR}/enrollments/${org}/users/${org}admin/tls/keystore/key.pem \
@@ -283,7 +283,7 @@ function join_channel_peer() {
 
   peer channel join \
     --blockpath ${TEMP_DIR}/genesis_block.pb \
-    --orderer   ${NS}-org0-orderersnode1-orderer.${DOMAIN} \
+    --orderer   ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN} \
     --tls        \
     --cafile    ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
 }

--- a/sample-network/scripts/channel.sh
+++ b/sample-network/scripts/channel.sh
@@ -282,8 +282,9 @@ function join_channel_peer() {
   export_peer_context $orgnum $peernum
 
   peer channel join \
-    --blockpath ${TEMP_DIR}/genesis_block.pb \
-    --orderer   ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN} \
-    --tls        \
-    --cafile    ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
+    --blockpath   ${TEMP_DIR}/genesis_block.pb \
+    --orderer     ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN} \
+    --connTimeout ${ORDERER_TIMEOUT} \
+    --tls         \
+    --cafile      ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
 }

--- a/sample-network/scripts/cluster.sh
+++ b/sample-network/scripts/cluster.sh
@@ -88,19 +88,19 @@ function kind_load_images() {
 }
 
 function cluster_init() {
-#  apply_fabric_crds
-#  apply_nginx_ingress
-#
-#  if [ "${STAGE_DOCKER_IMAGES}" == true ]; then
-#    pull_docker_images
-#    kind_load_images
-#  fi
+  apply_fabric_crds
+  apply_nginx_ingress
+
+  if [ "${STAGE_DOCKER_IMAGES}" == true ]; then
+    pull_docker_images
+    kind_load_images
+  fi
 
   if [ "${COREDNS_DOMAIN_OVERRIDE}" == true ]; then
     apply_coredns_domain_override
   fi
 
-#  wait_for_nginx_ingress
+  wait_for_nginx_ingress
 }
 
 function apply_fabric_crds() {

--- a/sample-network/scripts/console.sh
+++ b/sample-network/scripts/console.sh
@@ -21,9 +21,6 @@ function console_up() {
 
   init_namespace
 
-  # TODO: remove
-  create_image_pull_secret ghcr-pull-secret ghcr.io USERNAME $GITHUB_TOKEN
-
   apply_operator
   wait_for_deployment fabric-operator
 

--- a/sample-network/scripts/prereqs.sh
+++ b/sample-network/scripts/prereqs.sh
@@ -52,12 +52,18 @@ function check_prereqs() {
   bin/peer version &> /dev/null
   if [[ $? -ne 0 ]]; then
     echo "Downloading LATEST Fabric binaries and config"
-    curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/bootstrap.sh | bash -s -- -s -d
 
-    # remove sample config files extracted by the installation script
-    rm config/configtx.yaml
-    #rm config/core.yaml
-    rm config/orderer.yaml
+    mkdir -p $TEMP_DIR
+
+    # The download / installation of binaries will also transfer a core.yaml, which overlaps with a local configuration.
+    # Pull the binaries into a temp folder and then move them into the target location.
+    (pushd $TEMP_DIR && curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/main/scripts/bootstrap.sh | bash -s -- -s -d)
+    mkdir bin && mv $TEMP_DIR/bin/* bin
+
+    # delete config files transferred by the installer
+    rm $TEMP_DIR/config/configtx.yaml
+    rm $TEMP_DIR/config/core.yaml
+    rm $TEMP_DIR/config/orderer.yaml
   fi
 
   export PATH=bin:$PATH

--- a/sample-network/scripts/test_network.sh
+++ b/sample-network/scripts/test_network.sh
@@ -29,9 +29,6 @@ function network_up() {
 
   init_namespace
 
-  # TODO: remove
-  create_image_pull_secret ghcr-pull-secret ghcr.io USERNAME $GITHUB_TOKEN
-
   apply_operator
   wait_for_deployment fabric-operator
 

--- a/sample-network/scripts/utils.sh
+++ b/sample-network/scripts/utils.sh
@@ -146,7 +146,7 @@ function export_peer_context() {
 #  export FABRIC_LOGGING_SPEC=DEBUG
 
   export FABRIC_CFG_PATH=${PWD}/config
-  export CORE_PEER_ADDRESS=${NS}-${org}-${peer}-peer.${DOMAIN}:443
+  export CORE_PEER_ADDRESS=${NS}-${org}-${peer}-peer.${INGRESS_DOMAIN}:443
   export CORE_PEER_LOCALMSPID=Org${orgnum}MSP
   export CORE_PEER_TLS_ENABLED=true
   export CORE_PEER_MSPCONFIGPATH=${TEMP_DIR}/enrollments/${org}/users/${org}admin/msp


### PR DESCRIPTION
This PR introduces a coreDNS bypass / loop from pods running in kubernetes back to the ingress controller bound to a port on the host OS.

In previous environments, this required an overly complicated mangling of *.nip.io domains to find the cluster ingress controller.  With this approach, the Kube / coredns implements the wildcard domain `*.localho.st`, effectively hijacking the loopback resolver to point to the Nginx ingress running on the host.

With this scheme: 
- DNS queries for *.localho.st on the HOST always resolve to 127.0.0.1 (Ingress / nginx on the host) 
- DNS queries for *.localho.st in k8s Pods always resolve to `host.docker.internal` (Ingress / nginx on the host) 

This scheme can still be improved.  But it is a HUGE improvement over working with the *.vcap.me and *.nip.io domain resolvers. 