### PR TITLE
Update Orderer --connTimeout

### DIFF
--- a/sample-network/config/core.yaml
+++ b/sample-network/config/core.yaml
@@ -357,7 +357,7 @@ peer:
     # CLI common client config options
     client:
         # connection timeout
-        connTimeout: 10s
+        connTimeout: 15s
 
     # Delivery service related config
     deliveryclient:
@@ -366,7 +366,7 @@ peer:
         reconnectTotalTimeThreshold: 3600s
 
         # It sets the delivery service <-> ordering service node connection timeout
-        connTimeout: 10s
+        connTimeout: 15s
 
         # It sets the delivery service maximal delay between consecutive retries
         reConnectBackoffThreshold: 3600s

--- a/sample-network/network
+++ b/sample-network/network
@@ -62,7 +62,7 @@ context CONSOLE_PASSWORD          password
 
 # TODO: use new cc logic from test-network
 context CHANNEL_NAME              mychannel
-context ORDERER_TIMEOUT           10s
+context ORDERER_TIMEOUT           15s
 context CHAINCODE_NAME            asset-transfer-basic
 context CHAINCODE_IMAGE           ghcr.io/hyperledgendary/fabric-ccaas-asset-transfer-basic:latest
 context CHAINCODE_LABEL           basic_1.0
@@ -193,4 +193,3 @@ else
   print_help
   exit 1
 fi
-

--- a/sample-network/scripts/chaincode.sh
+++ b/sample-network/scripts/chaincode.sh
@@ -113,7 +113,8 @@ function invoke_chaincode() {
     -C              $CHANNEL_NAME \
     -c              $@ \
     --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
-    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
+    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem \
+    --connTimeout   ${ORDERER_TIMEOUT}
 
   sleep 2
 }
@@ -187,7 +188,7 @@ function launch_chaincode_service() {
   local cc_image=$5
   push_fn "Launching chaincode container \"${cc_image}\""
 
-  cat << EOF | envsubst | kubectl -n $NS apply -f - 
+  cat << EOF | envsubst | kubectl -n $NS apply -f -
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -286,7 +287,8 @@ function approve_chaincode() {
     --package-id    ${cc_id} \
     --sequence      1 \
     --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
-    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
+    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem \
+    --connTimeout   ${ORDERER_TIMEOUT}
 
   pop_fn
 }
@@ -307,7 +309,8 @@ function commit_chaincode() {
     --version       1 \
     --sequence      1 \
     --orderer       ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN}:443 \
-    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
+    --tls --cafile  ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem \
+    --connTimeout   ${ORDERER_TIMEOUT}
 
   pop_fn
 }

--- a/sample-network/scripts/channel.sh
+++ b/sample-network/scripts/channel.sh
@@ -282,9 +282,5 @@ function join_channel_peer() {
   export_peer_context $orgnum $peernum
 
   peer channel join \
-    --blockpath   ${TEMP_DIR}/genesis_block.pb \
-    --orderer     ${NS}-org0-orderersnode1-orderer.${INGRESS_DOMAIN} \
-    --connTimeout ${ORDERER_TIMEOUT} \
-    --tls         \
-    --cafile      ${TEMP_DIR}/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem
+    --blockpath   ${TEMP_DIR}/genesis_block.pb
 }


### PR DESCRIPTION
Add orderer timeout on chaincode calls.
Remove orderer flags on "peer channel join" since no connection to orderer is made.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>