### PR TITLE
Switch from Host OS ingress to EXTERNAL-IP ingress for internal traffic - READY FOR MERGE

### DIFF
--- a/.github/workflows/endtoend-tests.yaml
+++ b/.github/workflows/endtoend-tests.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright contributors to the Hyperledger Fabric Operator project
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Sample Network E2E Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sample Network E2E Test
+        run: sample-network/scripts/run-e2e-test.sh || cat sample-network/network-debug.log

--- a/config/ingress/k3s/kustomization.yaml
+++ b/config/ingress/k3s/kustomization.yaml
@@ -23,3 +23,15 @@ resources:
 
 patchesStrategicMerge:
   - ingress-nginx-controller.yaml
+
+# Remove the port `appProtocol` attribute as this is not accepted by all cloud providers
+patchesJson6902:
+  - target:
+      kind: Service
+      name: ingress-nginx-controller
+      version: v1
+    patch: |-
+      - op: remove
+        path: "/spec/ports/0/appProtocol"
+      - op: remove
+        path: "/spec/ports/1/appProtocol"

--- a/sample-network/README.md
+++ b/sample-network/README.md
@@ -245,7 +245,29 @@ export TEST_NETWORK_STORAGE_CLASS="local-path"
 
 
 ### IKS 
-For installations at IBM Cloud, use the EKS configuration settings below:
+For installations at IBM Cloud, use the following configuration settings:
+
+```shell
+export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
+export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE="false"
+export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
+export TEST_NETWORK_STORAGE_CLASS="ibm-file-gold"
+```
+
+To determine the external IP address for the Nginx ingress controller:
+
+1. Run `network cluster init` to create the Nginx resources
+2. Determine the IP address for the Nginx EXTERNAL-IP: 
+```shell
+INGRESS_IPADDR=$(kubectl -n ingress-nginx get svc/ingress-nginx-controller -o json | jq -r .status.loadBalancer.ingress[0].ip)
+```
+3. Set a virtual host domain resolving `*.EXTERNAL-IP.nip.io` or a public DNS wildcard resolver:
+```shell
+export TEST_NETWORK_INGRESS_DOMAIN=$(echo $INGRESS_IPADDR | tr -s '.' '-').nip.io
+```
+
+For additional guidelines on configuring ingress and DNS, see [Considerations for Kubernetes Distributions](https://cloud.ibm.com/docs/blockchain-sw-252?topic=blockchain-sw-252-deploy-k8#console-deploy-k8-considerations).
+
 
 ### EKS 
 
@@ -273,6 +295,9 @@ INGRESS_IPADDR=$(dig $INGRESS_HOSTNAME +short)
 ```shell
 export TEST_NETWORK_INGRESS_DOMAIN=$(echo $INGRESS_IPADDR | tr -s '.' '-').nip.io
 ```
+
+For additional guidelines on configuring ingress and DNS, see [Considerations for Kubernetes Distributions](https://cloud.ibm.com/docs/blockchain-sw-252?topic=blockchain-sw-252-deploy-k8#console-deploy-k8-considerations).
+
 
 ## Vagrant: fabric-devenv 
 

--- a/sample-network/README.md
+++ b/sample-network/README.md
@@ -16,138 +16,56 @@ Feedback, comments, questions, etc. at Discord : [#fabric-kubernetes](https://di
 
 ### General
 
-- Kubernetes - one of:
-  - [KIND](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) + [Docker](https://www.docker.com) (resources: 8 CPU / 8 GRAM)
-  - [Rancher Desktop](https://rancherdesktop.io) (resources: 8 CPU / 8GRAM, mobyd, and disable Traefik)
-  - Cloud instance hosted at IKS or EKS
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [jq](https://stedolan.github.io/jq/)
 - [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html) (`brew install gettext` on OSX)
-- Recommended: [k9s](https://k9scli.io)
-
-
-### DNS Domain
-
-Fabric-operator utilizes Kubernetes `Ingress` resources to expose services behind a common, unified
-DNS wildcard domain (e.g. `*.my-blockchain.example.com`).  In typical cloud-based environments, a DNS administrator
-is responsible for registering a public [DNS Wildcard Record](https://en.wikipedia.org/wiki/Wildcard_DNS_record),
-associating a virtual domain name with the IP address of a load balancer or cluster Ingress controller.
-For additional guidelines on public DNS, see [Considerations for Kubernetes Distributions](https://cloud.ibm.com/docs/blockchain-sw-252?topic=blockchain-sw-252-deploy-k8#console-deploy-k8-considerations).
-
-
-For environments with a domain registered in public DNS, set the domain attribute and proceed to
-[network setup](#test-network):
-
-```shell
-export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE=false
-export TEST_NETWORK_INGRESS_DOMAIN=my-blockchain.example.com
-```
-
-To enable _local development_ without a public DNS resolver, the sample network has been bundled with
-an Nginx ingress controller preconfigured in [ssl-passthrough](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) mode
-for TLS termination directly at the Fabric nodes.  By default the ingress will expose fabric services at the
-`*.localho.st` virtual domain, forcing all traffic from the host OS to be directed to the loopback interface.
-(localho.st is a public domain with wildcard resolver to 127.0.0.1.)
-
-For local development environments without write access to public DNS, set the ingress domain to the loopback interface:
-```shell
-export TEST_NETWORK_INGRESS_DOMAIN=localho.st
-```
-
-### Ingress IP Address
-
-**Important**:
-
-Before launching the network, you must determine an IP address where pods running in Kubernetes have a 
-network route to the ingress controller.
-
-While this will vary from system to system, the ingress IP can be determined with the following guidelines:
-
-
-#### KIND + OSX
-For KIND clusters running on OSX, determine the ingress IP by resolving `host.docker.internal` in a container:
-```shell
-docker run -it --rm alpine nslookup host.docker.internal
-```
-```
-Non-authoritative answer:
-Name:	host.docker.internal
-Address: 192.168.65.2
-```
-
-```shell
-export TEST_NETWORK_INGRESS_IPADDR=192.168.65.2
-```
-
-#### Windows / WSL2
-Determine the host IP address according to [Microsoft guidelines](https://docs.microsoft.com/en-us/windows/wsl/networking):
-```shell
-export TEST_NETWORK_INGRESS_IPADDR=$(ip -json addr | jq -r '.[] | select(.ifname=="eth0") | .addr_info[] | select(.family=="inet") | .local')
-```
-
-#### Embedded VMs
-
-For embedded virtual machines such as Vagrant, VirtualBox, VMWare, lima, etc., use the IP address of the
-guest bridge interface:
-```shell
-export TEST_NETWORK_INGRESS_IPADDR=$(hostname -I | cut -d " " -f 1)
-```
-
-#### Rancher / k3s
-
-On machines running [Rancher / k3s](https://rancherdesktop.io), use the host IP address assigned by DHCP 
-(e.g. 192.168.1.42).
-
-In addition to ingress IP, k3s clusters require the following settings:
-```shell
-export TEST_NETWORK_INGRESS_IPADDR=$(ipconfig getifaddr en0)
-
-export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
-export TEST_NETWORK_STORAGE_CLASS="local-path"
-export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
-```
-
-
-#### Amazon EKS
-
-For deployments to public cloud, run `network cluster init` and use kubectl to determine the IP address of the
-[Nginx ingress node](#amazon-kubernetes-service).
-
-In addition to ingress IP, EKS clusters require the following settings: 
-
-```shell
-export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
-export TEST_NETWORK_STORAGE_CLASS="gp2"
-export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
-export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE=false
-```
-
-
-### Fabric Binaries
-
-Fabric binaries (peer, osnadmin, etc.) will be installed into the local `bin` folder.  Add these to your PATH:
+- [k9s](https://k9scli.io) (recommended)
+- Fabric binaries (peer, osnadmin, etc.) will be installed into the local `bin` folder.  Add these to your PATH:
 
 ```shell
 export PATH=$PWD:$PWD/bin:$PATH
 ```
 
-In the examples below, the `peer` binary will be used to invoke smart contracts on the org1-peer1 ledger.  Set the CLI context with:
-```shell
-export FABRIC_CFG_PATH=${PWD}/temp/config
-export CORE_PEER_LOCALMSPID=Org1MSP
-export CORE_PEER_ADDRESS=test-network-org1-peer1-peer.${TEST_NETWORK_INGRESS_DOMAIN}:443
-export CORE_PEER_TLS_ENABLED=true
-export CORE_PEER_MSPCONFIGPATH=${PWD}/temp/enrollments/org1/users/org1admin/msp
-export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/temp/channel-msp/peerOrganizations/org1/msp/tlscacerts/tlsca-signcert.pem
-```
 
+### Kubernetes
 
-## Test Network
-
-Create a KIND Kubernetes cluster (skip if using Rancher or a cloud-hosted instance):
+If you do not have access to a Kubernetes cluster, create a local instance with [KIND](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+and [Docker](https://www.docker.com) (+ resources to 8 CPU / 8GRAM):
 ```shell
 network kind
 ```
+
+For additional cluster options, see the detailed guidelines for:
+- [Rancher Desktop](#rancher-desktop): k3s
+- [fabric-devenv](#vagrant-fabric-devenv): vagrant VM
+- [IKS](#iks)
+- [EKS](#eks)
+- [OCP](#ocp)
+
+
+### DNS Domain
+
+The operator utilizes Kubernetes `Ingress` resources to expose Fabric services at a common [DNS wildcard domain](https://en.wikipedia.org/wiki/Wildcard_DNS_record)
+(e.g. `*.test-network.example.com`).  For convenience, the sample network includes an Nginx ingress controller,
+pre-configured with [ssl-passthrough](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough)
+for TLS termination at the node endpoints.
+
+For **local clusters**, set the ingress wildcard domain to the host loopback interface (127.0.0.1):
+```shell
+export TEST_NETWORK_INGRESS_DOMAIN=localho.st
+```
+
+For **cloud-based clusters**, set the ingress wildcard domain to the public DNS A record:
+```shell
+export TEST_NETWORK_INGRESS_DOMAIN=test-network.example.com
+```
+
+For additional guidelines on configuring ingress and DNS, see [Considerations for Kubernetes Distributions](https://cloud.ibm.com/docs/blockchain-sw-252?topic=blockchain-sw-252-deploy-k8#console-deploy-k8-considerations).
+
+
+
+
+## Sample Network
 
 Install the Nginx controller and Fabric CRDs:
 ```shell
@@ -164,13 +82,28 @@ Explore Kubernetes `Pods`, `Deployments`, `Services`, `Ingress`, etc.:
 kubectl -n test-network get all
 ```
 
+
 ## Chaincode
 
-The operator is compatible with sample _Chaincode-as-a-Service_ smart contracts.
+In the examples below, the `peer` binary will be used to invoke smart contracts on the org1-peer1 ledger.  Set the CLI context with:
+```shell
+export FABRIC_CFG_PATH=${PWD}/temp/config
+export CORE_PEER_LOCALMSPID=Org1MSP
+export CORE_PEER_ADDRESS=test-network-org1-peer1-peer.${TEST_NETWORK_INGRESS_DOMAIN}:443
+export CORE_PEER_TLS_ENABLED=true
+export CORE_PEER_MSPCONFIGPATH=${PWD}/temp/enrollments/org1/users/org1admin/msp
+export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/temp/channel-msp/peerOrganizations/org1/msp/tlscacerts/tlsca-signcert.pem
+```
+
+### Chaincode as a Service
+
+The operator is compatible with sample _Chaincode-as-a-Service_ smart contracts and the `ccaas` external builder.
+When using the ccaas builder, the chaincode pods must be [started and running](scripts/chaincode.sh#L183) in the cluster
+before the contract can be approved on the channel.
 
 Clone the [fabric-samples](https://github.com/hyperledger/fabric-samples) git repository:
 ```shell
-git clone git@github.com:hyperledger/fabric-samples.git /tmp/fabric-samples
+git clone https://github.com/hyperledger/fabric-samples.git /tmp/fabric-samples
 ```
 
 Create a channel:
@@ -193,10 +126,11 @@ peer chaincode query -n asset-transfer-basic -C mychannel -c '{"Args":["org.hype
 ```
 
 
-## K8s Chaincode Builder
+### K8s Chaincode Builder
 
-The operator can also be configured for use with the [fabric-builder-k8s](https://github.com/hyperledgendary/fabric-builder-k8s)
-chaincode builder, providing smooth and immediate _Chaincode Right Now!_ deployments.
+The operator can also be configured for use with [fabric-builder-k8s](https://github.com/hyperledgendary/fabric-builder-k8s),
+providing smooth and immediate _Chaincode Right Now!_ deployments.  With the `k8s` builder, the peer node will directly
+manage the lifecycle of the chaincode pods.
 
 Reconstruct the network with the "k8s-fabric-peer" image:
 ```shell
@@ -275,15 +209,85 @@ Launch the [Fabric Operations Console](https://github.com/hyperledger-labs/fabri
 network console
 ```
 
-- open `https://test-network-hlf-console-console.localho.st`
+- open `https://test-network-hlf-console-console.${TEST_NETWORK_INGRESS_DOMAIN}`
 - Accept the self-signed TLS certificate
 - Log in as `admin:password`
 - [Build a network](https://cloud.ibm.com/docs/blockchain?topic=blockchain-ibp-console-build-network)
 
 
+
+## Appendix: Alternate k8s Runtimes
+
+### Rancher Desktop
+
+An excellent alternative for local development is the k3s distribution bundled with [Rancher Desktop](https://rancherdesktop.io).
+
+1. Increase cluster resources to 8 CPU / 8GRAM
+2. Select mobyd or containerd runtime
+3. Disable the Traefik ingress
+4. Restart Kubernetes
+
+For use with mobyd / Docker container:
+```shell
+export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
+export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
+export TEST_NETWORK_STORAGE_CLASS="local-path"
+```
+
+For use with containerd: 
+```shell
+export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
+export TEST_NETWORK_CONTAINER_CLI="nerdctl"
+export TEST_NETWORK_CONTAINER_NAMESPACE="--namespace k8s.io"
+export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
+export TEST_NETWORK_STORAGE_CLASS="local-path"
+```
+
+
+### IKS 
+For installations at IBM Cloud, use the EKS configuration settings below:
+
+### EKS 
+
+For installations at Amazon's Elastic Kubernetes Service, use the following settings:
+```shell
+export TEST_NETWORK_CLUSTER_RUNTIME="k3s"
+export TEST_NETWORK_COREDNS_DOMAIN_OVERRIDE="false"
+export TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
+export TEST_NETWORK_STORAGE_CLASS="gp2"
+```
+
+As an alternative to registering a public DNS domain with Route 54, the [Dead simple wildcard DNS for any IP Address](https://nip.io)
+service may be used to associate the Nginx external IP with an `nip.io` domain.
+
+To determine the external IP address for the ingress controller:
+
+1. Run `network cluster init` to create the Nginx resources.
+2. Wait for the ingress to come up and the hostname to propagate through public DNS (this will take a few minutes.)
+3. Determine the IP address for the Nginx EXTERNAL-IP:
+```shell
+INGRESS_HOSTNAME=$(kubectl -n ingress-nginx get svc/ingress-nginx-controller -o json  | jq -r .status.loadBalancer.ingress[0].hostname)
+INGRESS_IPADDR=$(dig $INGRESS_HOSTNAME +short)
+```
+4. Set a virtual host domain resolving `*.EXTERNAL-IP.nip.io` to the ingress IP:
+```shell
+export TEST_NETWORK_INGRESS_DOMAIN=$(echo $INGRESS_IPADDR | tr -s '.' '-').nip.io
+```
+
+## Vagrant: fabric-devenv 
+
+The [fabric-devenv](https://github.com/hyperledgendary/fabric-devenv) project will create a local development Virtual
+Machine, including all required prerequisites for running a KIND cluster and the sample network.
+
+To work around an issue resolving the kube DNS hostnames in vagrant, override the internal DNS name for Fabric services with:
+
+```shell
+export TEST_NETWORK_KUBE_DNS_DOMAIN=test-network
+```
+
+
 ## Troubleshooting Tips
 
-#### Logs
 - The `network` script prints output and progress to a `network-debug.log` file.  In a second shell:
 ```shell
 tail -f network-debug.log
@@ -294,16 +298,6 @@ tail -f network-debug.log
 kubectl -n test-network logs -f deployment/fabric-operator
 ```
 
-#### DNS
-
-- KIND running under the vagrant based [Fabric developer environment](https://github.com/hyperledgendary/fabric-devenv)
-  has problems resolving hosts on the kubernetes network domain `*.NAMESPACE.svc.cluster.local`, which is used for all
-  of the cross node/peer/orderer traffic.  As a workaround, the host suffix can be shortened, forcing the k8s-based
-  traffic to use the kube DNS:
-```shell
-export TEST_NETWORK_KUBE_DNS_DOMAIN=test-network
-```
-
 
 - On OSX, there is a bug in the Golang DNS resolver ([Fabric #3372](https://github.com/hyperledger/fabric/issues/3372) and [Golang #43398](https://github.com/golang/go/issues/43398)),
   causing the Fabric binaries to occasionally stall out when querying DNS.
@@ -312,36 +306,8 @@ export TEST_NETWORK_KUBE_DNS_DOMAIN=test-network
   from `fabric/build/bin/*` --> `sample-network/bin`
 
 
-#### Amazon Kubernetes Service
-
-- For deployments on EKS / Amazon cloud, it is possible to route traffic to the cluster ingress using the
-  [Dead simple wildcard DNS for any IP Address](https://nip.io) service as an alternative to creating
-  a public DNS record with Route 54.  For installation to EKS instances:
-
-0. Set general properties for EKS:
-```shell
-declare -x TEST_NETWORK_CLUSTER_RUNTIME="k3s"
-declare -x TEST_NETWORK_STAGE_DOCKER_IMAGES="false"
-declare -x TEST_NETWORK_STORAGE_CLASS="gp2"
-```
-
-2. Initialize the Nginx ingress controller:
-```shell
-network cluster init
-```
-2. Determine the IP of the Ingress load balancer (EXTERNAL-IP)
-```shell
-$ kubectl -n ingress-nginx get svc/ingress-nginx-controller
-NAME                       TYPE           CLUSTER-IP   EXTERNAL-IP                                PORT(S)
-ingress-nginx-controller   LoadBalancer   10.1.1.10    xyzzy-abc123.us-east-1.elb.amazonaws.com   80:32545/TCP,443:30341/TCP
-
-$ nslookup xyzzy.us-east-1.elb.amazonaws.com
-Non-authoritative answer:
-Name:	xyzzy-abc123.us-east-1.elb.amazonaws.com
-Address: 55.1.1.101               # Not a real IP address - use this value
-```
-
-3. Deploy the network using a nip.io wildcard domain, directing hosts to the ingress EXTERNAL-IP:
-```shell
-export TEST_NETWORK_INGRESS_DOMAIN=55-1-1-101.nip.io
-```
+- Both Fabric and Kubernetes are complex systems.  On occasion, things don't always work as they should, and it's
+  impossible to enumerate all failure cases that can come up in the wild.  When something in kube doesn't come up
+  correctly, use the [k9s](https://k9scli.io) (or another K8s navigator) to browse deployments, pods, services,
+  and logs.  Usually hitting `d` (describe) on a stuck resource in the `test-network` namespace is enough to
+  determine the source of the error.

--- a/sample-network/scripts/cluster.sh
+++ b/sample-network/scripts/cluster.sh
@@ -140,6 +140,9 @@ function delete_nginx_ingress() {
 function wait_for_nginx_ingress() {
   push_fn "Waiting for ingress controller"
 
+  # Give the ingress controller a chance to get set up in the namespace
+  sleep 5
+
   kubectl wait --namespace ingress-nginx \
     --for=condition=ready pod \
     --selector=app.kubernetes.io/component=controller \

--- a/sample-network/scripts/run-e2e-test.sh
+++ b/sample-network/scripts/run-e2e-test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+#
+# Copyright contributors to the Hyperledger Fabric Operator project
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# 	  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o errexit
+
+cd "$(dirname "$0")/.."
+
+# Dump out the error log if we are exiting with a nonzero error code
+function exit_fn() {
+  rc=$?
+  set +x
+
+  if [ "0" -ne $rc ]; then
+    cat network-debug.log
+  fi
+}
+
+# Call the exit handler when we exit.
+trap "exit_fn" EXIT
+
+export PATH=$PWD:$PWD/bin:$PATH
+export TEST_NETWORK_INGRESS_DOMAIN=localho.st
+
+echo "Starting E2E Test.  Environment:"
+printenv | sort
+
+# Set up a cluster
+network kind
+
+# Set up ngress and CRDs
+network cluster init
+
+# Set up a Fabric Network
+network up
+
+kubectl -n test-network get all
+
+
+# Chaincode: general
+
+export FABRIC_CFG_PATH=${PWD}/temp/config
+export CORE_PEER_LOCALMSPID=Org1MSP
+export CORE_PEER_ADDRESS=test-network-org1-peer1-peer.${TEST_NETWORK_INGRESS_DOMAIN}:443
+export CORE_PEER_TLS_ENABLED=true
+export CORE_PEER_MSPCONFIGPATH=${PWD}/temp/enrollments/org1/users/org1admin/msp
+export CORE_PEER_TLS_ROOTCERT_FILE=${PWD}/temp/channel-msp/peerOrganizations/org1/msp/tlscacerts/tlsca-signcert.pem
+
+
+## ccaas
+
+rm -rf /tmp/fabric-samples || true
+git clone https://github.com/hyperledger/fabric-samples.git /tmp/fabric-samples
+
+network channel create
+
+network cc deploy   asset-transfer-basic basic_1.0 /tmp/fabric-samples/asset-transfer-basic/chaincode-java
+
+network cc metadata asset-transfer-basic
+network cc invoke   asset-transfer-basic '{"Args":["InitLedger"]}'
+network cc query    asset-transfer-basic '{"Args":["ReadAsset","asset1"]}' | jq
+
+peer chaincode query -n asset-transfer-basic -C mychannel -c '{"Args":["org.hyperledger.fabric:GetMetadata"]}'
+
+
+## k8s-builder
+
+network down
+
+export TEST_NETWORK_PEER_IMAGE=ghcr.io/hyperledgendary/k8s-fabric-peer
+export TEST_NETWORK_PEER_IMAGE_LABEL=v0.5.0
+
+network up
+network channel create
+
+curl -fsSL https://github.com/hyperledgendary/conga-nft-contract/releases/download/v0.1.1/conga-nft-contract-v0.1.1.tgz -o conga-nft-contract-v0.1.1.tgz
+
+peer lifecycle chaincode install conga-nft-contract-v0.1.1.tgz
+
+export PACKAGE_ID=$(peer lifecycle chaincode calculatepackageid conga-nft-contract-v0.1.1.tgz) && echo $PACKAGE_ID
+
+peer lifecycle \
+  chaincode approveformyorg \
+  --channelID     mychannel \
+  --name          conga-nft-contract \
+  --version       1 \
+  --package-id    ${PACKAGE_ID} \
+  --sequence      1 \
+  --orderer       test-network-org0-orderersnode1-orderer.${TEST_NETWORK_INGRESS_DOMAIN}:443 \
+  --tls --cafile  $PWD/temp/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem \
+  --connTimeout   15s
+
+peer lifecycle \
+  chaincode commit \
+  --channelID     mychannel \
+  --name          conga-nft-contract \
+  --version       1 \
+  --sequence      1 \
+  --orderer       test-network-org0-orderersnode1-orderer.${TEST_NETWORK_INGRESS_DOMAIN}:443 \
+  --tls --cafile  $PWD/temp/channel-msp/ordererOrganizations/org0/orderers/org0-orderersnode1/tls/signcerts/tls-cert.pem \
+  --connTimeout   15s
+
+kubectl -n test-network describe pods -l app.kubernetes.io/created-by=fabric-builder-k8s
+
+peer chaincode query -n conga-nft-contract -C mychannel -c '{"Args":["org.hyperledger.fabric:GetMetadata"]}'
+
+network down


### PR DESCRIPTION
This PR: 

- Switches to a CLUSTER-IP network interface for communication with the K8s Ingress

- Adds configuration notes for EKS and IKS clusters 

- Adds a `M.E.L.V.I.N.` ("Cousin of MARVIN") style end-to-end test, including chaincode deployments for `ccaas` and `k8s` executors on a scratch / disposable KIND cluster.

With the previous configuration, the network domain was based on the HOST OS interface to route traffic through the ingress controller.  This was _extremely confusing_, as the network IP varied widely from environment to environment.  With the new scheme, pods communicate with the ingress controller via the Kube INTERNAL (CLUSTER_IP) interface, which does not require a route back to the host OS.

The resulting configuration / README / guidelines are _tremendously simplified_, as the cluster IP is readily available to both the setup scripts and the pods running in Kubernetes.

Tested on the following environments - all more or less ... _just work_:

- [X] EKS
- [X] IKS
- [X] KIND + OSX
- [X] WSL2
- [X] vagrant + fabric-devenv
- [X] Fyre : (peer lcient on fyre, localho,st ingress)
- [X] Fyre : (peer client on fyre, public DNS)
- [X] Fyre : peer client on localhost, remote kube at Fyre + public DNS
- [X] Rancher + moby
- [X] Rancher + containerd / nerdctl

👍 👍 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>
